### PR TITLE
remove `port_driven` from the definition of MarnavTask

### DIFF
--- a/nmea0183.orogen
+++ b/nmea0183.orogen
@@ -16,8 +16,6 @@ task_context "MarnavTask", subclasses: "iodrivers_base::Task" do
     needs_configuration
 
     output_port "nmea_stats", "/nmea0183/NMEAStats"
-
-    port_driven
 end
 
 task_context "test::MarnavTestTask", subclasses: "nmea0183::MarnavTask" do


### PR DESCRIPTION
This task only has outputs, no inputs, so that's meaningless.
Plus, it sets it up to use the RTT base activity instead of
the FileDescriptorActivity, which is actively harmful (the
task's won't trigger when data is available on I/O)

This is why `iodrivers_base::Task` calls port_driven first,
and then fd_driven