### PR TITLE
clear the data from the input on start

### DIFF
--- a/tasks/MarnavTask.cpp
+++ b/tasks/MarnavTask.cpp
@@ -42,6 +42,20 @@ bool MarnavTask::startHook()
     if (! MarnavTaskBase::startHook()) {
         return false;
     }
+
+    /** Flush any data already received. It might be a partial sentence, and
+     * since some NMEA devices are slow-sending (e.g. AIS), simply relying on
+     * receiving another message will timeout
+     */
+    static const int BUFFER_SIZE = marnav::nmea::sentence::max_length * 2;
+    uint8_t buffer[BUFFER_SIZE];
+    try {
+        while(true) {
+            mDriver->readPacket(buffer, BUFFER_SIZE, base::Time(), base::Time());
+        }
+    }
+    catch(iodrivers_base::TimeoutError&) {}
+
     return true;
 }
 void MarnavTask::updateHook()

--- a/test/MarnavTask_test.rb
+++ b/test/MarnavTask_test.rb
@@ -13,84 +13,101 @@ describe OroGen.nmea0183.MarnavTask do
         )
     end
 
-    before do
-        @task = deploy_task_under_test
+    describe "runtime behavior" do
+        before do
+            @task = deploy_task_under_test
 
-        # This complicated setup works around that data readers and writers
-        # in Syskit connect themselves only when their target tasks are running
-        #
-        # We need to be connected before configure
-        io_reader_writer_m = Syskit::DataService.new_submodel do
-            input_port "in", "/iodrivers_base/RawPacket"
-            output_port "out", "/iodrivers_base/RawPacket"
-        end
+            # This complicated setup works around that data readers and writers
+            # in Syskit connect themselves only when their target tasks are running
+            #
+            # We need to be connected before configure
+            io_reader_writer_m = Syskit::DataService.new_submodel do
+                input_port "in", "/iodrivers_base/RawPacket"
+                output_port "out", "/iodrivers_base/RawPacket"
+            end
 
-        cmp_m = Syskit::Composition.new_submodel do
-            add io_reader_writer_m, as: "reader_writer"
-            add OroGen.nmea0183.MarnavTask, as: "marnav"
+            cmp_m = Syskit::Composition.new_submodel do
+                add io_reader_writer_m, as: "reader_writer"
+                add OroGen.nmea0183.MarnavTask, as: "marnav"
 
-            reader_writer_child.connect_to marnav_child.io_raw_in_port
-            marnav_child.io_raw_out_port.connect_to reader_writer_child
-        end
-        cmp = syskit_stub_deploy_configure_and_start(
-            cmp_m.use("marnav" => @task, "reader_writer" => io_reader_writer_m)
-        )
-        @io = cmp.reader_writer_child
-
-        @xdr_sentence = make_packet("$IIXDR,C,19.52,C,TempAir*19\r\n")
-        @zda_sentence = make_packet("$GPZDA,160012.71,11,03,2004,-1,00*7D\r\n")
-        # Invalid number of fields, but format and checksum are valid
-        @invalid_zda_sentence = make_packet("$GPZDA,160012.71,03,2004,-1,00*51\r\n")
-    end
-
-    it "passes the received sentences to the subclass" do
-        sentence = expect_execution do
-            syskit_write @io.out_port, @xdr_sentence
-        end.to { have_one_new_sample task.received_sentences_port }
-        assert_equal "$IIXDR,C,19.52,C,TempAir*19", sentence
-    end
-
-    it "counts received sentences" do
-        stats = expect_execution do
-            syskit_write @io.out_port, @xdr_sentence
-        end.to { have_one_new_sample task.nmea_stats_port }
-        assert_equal 0, stats.invalid_sentences
-        assert_equal 1, stats.received_sentences
-        assert_equal 0, stats.ignored_sentences
-    end
-
-    it "counts ignored sentences" do
-        stats = expect_execution do
-            syskit_write @io.out_port, @zda_sentence
-        end.to { have_one_new_sample task.nmea_stats_port }
-        assert_equal 0, stats.invalid_sentences
-        assert_equal 1, stats.received_sentences
-        assert_equal 1, stats.ignored_sentences
-    end
-
-    it "counts sentences not recognized by marnav" do
-        stats = expect_execution do
-            syskit_write @io.out_port, @invalid_zda_sentence
-        end.to { have_one_new_sample task.nmea_stats_port }
-        assert_equal 1, stats.invalid_sentences
-        assert_equal 0, stats.received_sentences
-        assert_equal 0, stats.ignored_sentences
-    end
-
-    describe "processRawSentence" do
-        def deploy_task_under_test
-            syskit_deploy(
-                OroGen.nmea0183.test.MarnavProcessRawSentenceTask
-                      .deployed_as("marnav_task")
+                reader_writer_child.connect_to marnav_child.io_raw_in_port
+                marnav_child.io_raw_out_port.connect_to reader_writer_child
+            end
+            cmp = syskit_stub_deploy_configure_and_start(
+                cmp_m.use("marnav" => @task, "reader_writer" => io_reader_writer_m)
             )
+            @io = cmp.reader_writer_child
+
+            @xdr_sentence = make_packet("$IIXDR,C,19.52,C,TempAir*19\r\n")
+            @zda_sentence = make_packet("$GPZDA,160012.71,11,03,2004,-1,00*7D\r\n")
+            # Invalid number of fields, but format and checksum are valid
+            @invalid_zda_sentence = make_packet("$GPZDA,160012.71,03,2004,-1,00*51\r\n")
         end
 
-        it "lets the subclasses fine-tune the raw sentence" do
+        it "passes the received sentences to the subclass" do
             sentence = expect_execution do
                 syskit_write @io.out_port, @xdr_sentence
             end.to { have_one_new_sample task.received_sentences_port }
-            assert_equal "$GPZDA,160012.710,11,03,2004,-1,00*4D", sentence
+            assert_equal "$IIXDR,C,19.52,C,TempAir*19", sentence
         end
+
+        it "counts received sentences" do
+            stats = expect_execution do
+                syskit_write @io.out_port, @xdr_sentence
+            end.to { have_one_new_sample task.nmea_stats_port }
+            assert_equal 0, stats.invalid_sentences
+            assert_equal 1, stats.received_sentences
+            assert_equal 0, stats.ignored_sentences
+        end
+
+        it "counts ignored sentences" do
+            stats = expect_execution do
+                syskit_write @io.out_port, @zda_sentence
+            end.to { have_one_new_sample task.nmea_stats_port }
+            assert_equal 0, stats.invalid_sentences
+            assert_equal 1, stats.received_sentences
+            assert_equal 1, stats.ignored_sentences
+        end
+
+        it "counts sentences not recognized by marnav" do
+            stats = expect_execution do
+                syskit_write @io.out_port, @invalid_zda_sentence
+            end.to { have_one_new_sample task.nmea_stats_port }
+            assert_equal 1, stats.invalid_sentences
+            assert_equal 0, stats.received_sentences
+            assert_equal 0, stats.ignored_sentences
+        end
+
+        describe "processRawSentence" do
+            def deploy_task_under_test
+                syskit_deploy(
+                    OroGen.nmea0183.test.MarnavProcessRawSentenceTask
+                        .deployed_as("marnav_task")
+                )
+            end
+
+            it "lets the subclasses fine-tune the raw sentence" do
+                sentence = expect_execution do
+                    syskit_write @io.out_port, @xdr_sentence
+                end.to { have_one_new_sample task.received_sentences_port }
+                assert_equal "$GPZDA,160012.710,11,03,2004,-1,00*4D", sentence
+            end
+        end
+    end
+
+    it "handles receiving a partial sentence during start" do
+        @task = deploy_task_under_test
+
+        @task.properties.io_port = "udpserver://10000"
+        @task.properties.io_read_timeout = Time.at(0)
+        syskit_configure(@task)
+
+        socket = UDPSocket.new
+        socket.send("DR,C,19.52,C,TempAir*19", 0, "127.0.0.1", 10_000);
+        syskit_start(@task)
+        sleep 0.1
+        expect_execution { task.stop! }
+            .to { emit task.interrupt_event }
     end
 
     def make_packet(sentence)


### PR DESCRIPTION
See comments in the file. Basically, most NMEA0183 send continuously
*and* some of them are very slow (e.g. AIS). So, we may get a partial
message in the input I/O, while the next message is 30s away.

When this happens, processIO will be called and will timeout. Flush
data from input on startHook to avoid this.